### PR TITLE
REF-151 features checkout

### DIFF
--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -251,8 +251,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
             self.output((logger.info, "No such branch %r", branch))
             return
         else:
-            self.output((logger.error, "No such branch %r", branch))
-            sys.exit(1)
+            raise GitError("No such branch {}".format(branch))
         # runs the checkout with predetermined arguments
         self.git_run(argv, cwd=path)
 


### PR DESCRIPTION
This bug did not manifest in a `maas.minddistrict.com` buildout, but it did manifest in a `pero` buildout where it silently swallowed an error when a branch was missing.

I have not included reproduction buildouts, since they would be broken by design.

Now, in `pero` with a `features-checkout` for `discuss` that does not actually have the branch, it does:
```
REF-150-documentation  ~/maas/dev/pero
app@thor(minddistrict):pero$ bin/buildout 
mr.developer: Queued 'discuss' for checkout.
mr.developer: Queued 'ith' for checkout.
mr.developer: Queued 'md.angularjs' for checkout.
mr.developer: Queued 'md.content' for checkout.
mr.developer: Queued 'md.json' for checkout.
mr.developer: Queued 'md.l10n' for checkout.
mr.developer: Queued 'md.rest' for checkout.
mr.developer: Queued 'md.testing' for checkout.
The package 'mr.developer' is dirty.
Do you want to update it anyway? [yes/No/all] no
mr.developer: Skipped update of 'mr.developer'.
mr.developer: Auto-selecting branch REF-150-documentation
mr.developer: Updated 'discuss' with git.
mr.developer: No such branch REF-150-documentation
mr.developer: There have been errors, see messages above.
```

In `maas.minddistrict.com` with a `features-checkout` for `discuss` that does not actually have the branch, it does:
```
REF-151-features-checkout : NO REMOTE ~/maas3
app@thor(minddistrict):maas3$ bin/buildout 
mr.developer: Queued 'md.content' for checkout.
mr.developer: Queued 'mr.developer' for checkout.
mr.developer: Auto-selecting branch REF-151-features-checkout
mr.developer: Updated 'mr.developer' with git.
mr.developer: Switching to branch 'REF-151-features-checkout'.
mr.developer: Auto-selecting branch REF-151-features-checkout
mr.developer: Cloned 'md.content' with git using branch 'REF-151-features-checkout' from 'git@github.com:minddistrict/md.content'.
mr.developer: '/usr/bin/git clone --quiet -b REF-151-features-checkout git@github.com:minddistrict/md.content /app/maas3/dev/md.content'
mr.developer: 
mr.developer: fatal: Remote branch REF-151-features-checkout not found in upstream origin
mr.developer: 
mr.developer: There have been errors, see messages above.
```